### PR TITLE
Add javafx/** to classpath.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,11 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<accessrules>
+			<accessrule kind="accessible" pattern="javafx/**"/>
+		</accessrules>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
So that students don't get a surprise when Eclipse refuses to compile.

https://ivle.nus.edu.sg/v1/forum/board_read.aspx?forumid=5b7a6f75-58ed-4922-b8b0-ca761d166a6a&postid=a885b943-ae69-484f-aa4f-7e8db4074495&lpreferrer=&headingid=5d7d5e65-fba5-4876-a902-ed71d938a515&isNested=1
