### PR TITLE
executable jar file doesn't run #39

### DIFF
--- a/src/seedu/addressbook/ui/Gui.java
+++ b/src/seedu/addressbook/ui/Gui.java
@@ -36,7 +36,11 @@ public class Gui {
 
     private MainWindow createMainWindow(Stage stage, Stoppable mainApp) throws IOException{
         FXMLLoader loader = new FXMLLoader();
-        loader.setLocation(Main.class.getResource("ui" + File.separator + "mainwindow.fxml"));
+
+        // When calling getResource(), use '/', instead of File.separator or '\\'
+        // See: http://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html#res_name_context
+        loader.setLocation(Main.class.getResource("ui/mainwindow.fxml"));
+
         stage.setTitle(version);
         stage.setScene(new Scene(loader.load(), INITIAL_WINDOW_WIDTH, INITIAL_WINDOW_HEIGHT));
         stage.show();

--- a/src/seedu/addressbook/ui/Gui.java
+++ b/src/seedu/addressbook/ui/Gui.java
@@ -37,8 +37,9 @@ public class Gui {
     private MainWindow createMainWindow(Stage stage, Stoppable mainApp) throws IOException{
         FXMLLoader loader = new FXMLLoader();
 
-        // When calling getResource(), use '/', instead of File.separator or '\\'
-        // See: http://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html#res_name_context
+        /* Note: When calling getResource(), use '/', instead of File.separator or '\\'
+         * More info: http://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html#res_name_context
+         */
         loader.setLocation(Main.class.getResource("ui/mainwindow.fxml"));
 
         stage.setTitle(version);


### PR DESCRIPTION
When running it in .jar, Java does not allow the use of '\' (Windows
file separator), only allowing '/' (Unix file separator) in resource
filepaths.

~~Since MainWindow's .java file is in the same location as the .fxml file,
we can avoid this issue completely, by using MainWindow instead of
Main class for fxml loading.~~

EDIT: To ensure that future developers understand the issue, a link to the
documentation is provided and the separator is changed.

Fixes #39.