### PR TITLE
Set up Travis CI #45

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ test/data/
 /bin/
 /data/
 publish.sh
+
+# Gradle build files
+.gradle/
+build/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+matrix:
+  include:
+    - jdk: oraclejdk8
+
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/se-edu/addressbook-level3.svg?branch=master)](https://travis-ci.org/se-edu/addressbook-level3)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d4a0954383444a8db8cb26e5f5b7302c)](https://www.codacy.com/app/se-edu/addressbook-level3?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=se-edu/addressbook-level3&amp;utm_campaign=Badge_Grade)
 
 # AddressBook (Level 3)

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,41 @@
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src']
+        }
+    }
+    test {
+        java {
+            srcDirs = ['test/java']
+        }
+    }
+}
+
+dependencies {
+    testCompile 'junit:junit:4.12'
+}
+
+test {
+    /*
+     * Prints the currently running test's name in the CI's build log, 
+     * so that we can check if tests are being silently skipped or stalling the build.
+     */
+    if (System.env.'CI') {
+       beforeTest { descriptor ->
+           logger.lifecycle('Running test: ' + descriptor)
+       }
+    }
+}
+
+compileJava {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+}
+
+defaultTasks 'clean', 'test'


### PR DESCRIPTION
Closes #45 

This gradle build file is the bare minimum for travis CI and thus will not support the building of jar file using `gradlew build` as it requires the bundling of the wrapper file and additional plugins which is not the aim of this PR.