### PR TITLE
DeveloperGuide: update instructions to import project as gradle project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ sourceSets {
         java {
             srcDirs = ['src']
         }
+        resources {
+            srcDirs = ['src']
+        }
     }
     test {
         java {

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -20,23 +20,11 @@
 .. If JDK 8 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 8.
 .. Click `OK`.
 . Click `Import Project`
-. Locate the project directory and click `OK`
-. Select `Create project from existing sources` and click `Next`
-. Rename the project if you want. Click `Next`
-. Ensure that your `\src` and `\test\java` folder is checked. Keep clicking `Next`
-. Click `Finish`
-. Add JUnit 4 to classpath
-.. Open any test file in `\test\java` and place your cursor over any `@Test` highlighted in red
-.. Press ALT+ENTER and select `Add 'JUnit4' to classpath`
-.. Select `Use 'JUnit4' from IntelliJ IDEA distribution` and click `OK`
-. Run all the tests (right-click the `test` folder, and click `Run 'All Tests'`)
-. Observe how some tests fail. That is because they try to access the test data from the wrong directory (the working directory is expected to be the root directory, but IntelliJ runs the test with `test\` as the working directory by default). To fix this issue:
-.. Go to `Run` -> `Edit Configurations...`
-.. On the list at the left, expand `JUnit`, and remove all the test configurations (e.g. `All in test`) by selecting it and clicking on the '-' icon at the top of the list
-.. Expand `Defaults`, and ensure that `JUnit` is selected
-.. Under `Configuration`, change the `Working directory` to the `addressbook-level3` folder
-.. Click `OK`
-. Run the tests again to ensure they all pass now.
+. Locate the `build.gradle` file and select it. Click `OK`
+. Click `Open as Project`
+. Click `OK` to accept the default settings
+. Run the `seedu.addressbook.Main` class (right-click the `Main` class and click `Run Main.main()`) and try executing a few commands
+. Run all the tests (right-click the `test` folder, and click `Run 'All Tests'`) and ensure that they pass
 
 == Design
 


### PR DESCRIPTION
Part of #146 
```
The instructions for users for setting up of the project Intellij is to
import the project as an existing source.

In order to lessen the learning curve between AB3 and AB4, as well
as to import necessary 3rd party dependencies more easily, we should
update the instructions to import the project as a gradle project.

Let's update the instructions in DeveloperGuide to import the project
into Intellij as a gradle project.
```