### PR TITLE
Ensure Java 9 compatibility #146

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk8
+    - jdk: oraclejdk9
 
 script: >-
     ./gradlew test asciidoctor
@@ -16,4 +16,4 @@ deploy:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java9-installer

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.6'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_9
+targetCompatibility = JavaVersion.VERSION_1_9
 
 repositories {
     mavenCentral()
@@ -33,6 +33,11 @@ sourceSets {
 }
 
 dependencies {
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.8'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
+    implementation group: 'javax.activation', name: 'activation', version: '1.1.1'
+
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -9,7 +9,7 @@
 
 === Prerequisites
 
-* JDK 8 or later
+* JDK 9 or later
 * IntelliJ IDE
 
 === Importing the project into IntelliJ
@@ -17,8 +17,8 @@
 . Open IntelliJ (if you are not in the welcome screen, click `File` > `Close Project` to close the existing project dialog first)
 . Set up the correct JDK version
 .. Click `Configure` > `Project Defaults` > `Project Structure`
-.. If JDK 8 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 8.
-.. Click `OK`.
+.. If JDK 9 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 9
+.. Click `OK`
 . Click `Import Project`
 . Locate the `build.gradle` file and select it. Click `OK`
 . Click `Open as Project`
@@ -80,7 +80,7 @@ Use case resumes at step 2.
 [appendix]
 == Non Functional Requirements
 
-. Should work on any <<mainstream-os, mainstream OS>> as long as it has Java 8 or higher installed.
+. Should work on any <<mainstream-os, mainstream OS>> as long as it has Java 9 or higher installed.
 . Should be able to hold up to 1000 persons.
 . Should come with automated unit tests and open source code.
 . Should favor DOS style commands over Unix-style commands.

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -4,6 +4,7 @@
 :toc-title:
 :imagesDir: images
 :stylesDir: stylesheets
+:experimental:
 
 == Setting up
 
@@ -25,6 +26,9 @@
 . Click `OK` to accept the default settings
 . Run the `seedu.addressbook.Main` class (right-click the `Main` class and click `Run Main.main()`) and try executing a few commands
 . Run all the tests (right-click the `test` folder, and click `Run 'All Tests'`) and ensure that they pass
+. Open the `StorageFile` file and check for any code errors
+.. Due to an ongoing https://youtrack.jetbrains.com/issue/IDEA-189060[issue] with some of the newer versions of IntelliJ, code errors may be detected even if the project can be built and run successfully
+.. To resolve this, place your cursor over any of the code section highlighted in red. Press kbd:[ALT + ENTER], and select `Add '--add-modules=java.xml.bind' to module compiler options`
 
 == Design
 

--- a/test/java/seedu/addressbook/common/UtilsTest.java
+++ b/test/java/seedu/addressbook/common/UtilsTest.java
@@ -56,8 +56,8 @@ public class UtilsTest {
         assertNotUnique("abc", "abc");
         assertNotUnique("abc", "", "abc", "ABC");
         assertNotUnique("", "abc", "a", "abc");
-        assertNotUnique(1, new Integer(1));
-        assertNotUnique(null, 1, new Integer(1));
+        assertNotUnique(1, Integer.valueOf(1));
+        assertNotUnique(null, 1, Integer.valueOf(1));
         assertNotUnique(null, null);
         assertNotUnique(null, "a", "b", null);
     }


### PR DESCRIPTION
Fixes #146 
```
The project currently runs on Java 8.

Since AddressBookL4 is already running on Java 9, this project should
be upgraded to run on Java 9 as well for consistency.

Let's upgrade the project to run on Java 9 and update the
documentation accordingly.

Travis currently builds the project using JDK 8. Since we are now
running on Java 9, let's update it to build the project using JDK 9.

Java 9 introduces a module system. By default, the set of root modules
for unnamed modules is based on the java.se module instead of the
java.se.ee modules. Thus, APIs in modules from the java.se.ee module,
such as java.xml.bind, are not accessible by default[1]. As our project
is still an unnamed module which depends on the java.xml.bind module,
it is no longer compilable. To resolve this, let's update build.gradle
to import the dependencies for java.xml.bind.

UtilsTest uses the Integer(int) constructor for its equality test,
which is deprecated from Java 9[2]. Since use of deprecated APIs is
considered bad practice, let's replace this with Integer.valueOf(int).

[1]: http://openjdk.java.net/jeps/261
[2]: https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-int-
```